### PR TITLE
rename the openidtest machine to be oidctest

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ IPA will be at http://ipa.tinystage.test/ and fasjson at http://fasjson.tinystag
 
 Ipsilon is also accessible at: https://ipsilon.tinystage.test/idp
 
-And the tiny test application for testing out OpenID Connect with ipsilon is at https://openidtest.tinystage.test/
+And the tiny test application for testing out OpenID Connect with ipsilon is at https://oidctest.tinystage.test/
 
 The fas2ipa box contains a clone of the project of the same-name, pre-configured save for the FAS
 username and password. Set them in fas2ipa/config.toml and run fas2ipa like this:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ machines = {
   },
   "fasjson": {"autostart": true},
   "ipsilon": {"autostart": true},
-  "openidtest": {},
+  "oidctest": {},
   "fas2ipa": {},
   "noggin": {},
   "elections": {},

--- a/ansible/oidctest.yml
+++ b/ansible/oidctest.yml
@@ -1,9 +1,9 @@
 ---
-- hosts: openidtest
+- hosts: oidctest
   become: true
   become_method: sudo
   roles:
     - common
-    - openidtest
+    - oidctest
 
 

--- a/ansible/roles/elections/files/elections.service
+++ b/ansible/roles/elections/files/elections.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=openidtest
+Description=elections
 After=network-online.target
 Wants=network-online.target
 

--- a/ansible/roles/elections/tasks/main.yml
+++ b/ansible/roles/elections/tasks/main.yml
@@ -80,7 +80,7 @@
     insertafter: 'default_ccache_name.*'
     line: '  default_client_keytab_name = FILE:/etc/krb5.keytab'
 
-- name: Start openidtest service using systemd
+- name: Start elections service using systemd
   systemd:
     state: started
     name: elections

--- a/ansible/roles/oidctest/files/.bashrc
+++ b/ansible/roles/oidctest/files/.bashrc
@@ -1,0 +1,6 @@
+# .bashrc
+
+alias oidctest-start="sudo systemctl start oidctest.service && echo 'oidctest is running on https://oidctest.tinystage.test/'"
+alias oidctest-logs="sudo journalctl -u oidctest.service"
+alias oidctest-restart="sudo systemctl restart oidctest.service && echo 'oidctest is running on https://oidctest.tinystage.test/'"
+alias oidctest-stop="sudo systemctl stop oidctest.service && echo 'oidctest service stopped'"

--- a/ansible/roles/oidctest/files/app.py
+++ b/ansible/roles/oidctest/files/app.py
@@ -41,7 +41,7 @@ def landing_page():
     if OIDC.user_loggedin:
         return flask.redirect(flask.url_for('.logged_in'))
     else:
-        return flask.Response("Landing page, try to go to <a href='https://openidtest.tinystage.test/login'>https://openidtest.tinystage.test/login</a>")
+        return flask.Response("Landing page, try to go to <a href='https://oidctest.tinystage.test/login'>https://oidctest.tinystage.test/login</a>")
 
 @app.route("/login")
 def login():

--- a/ansible/roles/oidctest/files/oidctest.service
+++ b/ansible/roles/oidctest/files/oidctest.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=openidtest
+Description=oidctest
 After=network-online.target
 Wants=network-online.target
 

--- a/ansible/roles/oidctest/tasks/main.yml
+++ b/ansible/roles/oidctest/tasks/main.yml
@@ -17,10 +17,10 @@
     group: vagrant
 
 - name: Enroll system as IPA client
-  shell: ipa-client-install --hostname openidtest.tinystage.test --domain tinystage.test --realm {{ krb_realm }} --server ipa.tinystage.test -p {{ ipa_admin_user }} -w {{ ipa_admin_password }} -U -N --force-join
+  shell: ipa-client-install --hostname oidctest.tinystage.test --domain tinystage.test --realm {{ krb_realm }} --server ipa.tinystage.test -p {{ ipa_admin_user }} -w {{ ipa_admin_password }} -U -N --force-join
 
 - name: Generate and get SSL cert
-  shell: ipa-getcert request -f /etc/pki/tls/certs/server.pem -k /etc/pki/tls/private/server.key -K HTTP/openidtest.tinystage.test
+  shell: ipa-getcert request -f /etc/pki/tls/certs/server.pem -k /etc/pki/tls/private/server.key -K HTTP/oidctest.tinystage.test
 
 - name: Check the cert is there
   wait_for:
@@ -41,7 +41,7 @@
   shell: cat /etc/ipa/ca.crt >> /usr/lib/python3.8/site-packages/httplib2/cacerts.txt
 
 - name: register the application with oidc-register
-  shell: oidc-register --debug https://ipsilon.tinystage.test/idp/openidc/ https://openidtest.tinystage.test/oidc_callback
+  shell: oidc-register --debug https://ipsilon.tinystage.test/idp/openidc/ https://oidctest.tinystage.test/oidc_callback
   become: yes
   become_user: vagrant
   args:
@@ -55,18 +55,18 @@
     owner: vagrant
     group: vagrant
 
-- name: Install the systemd unit files for openidtest services
+- name: Install the systemd unit files for oidctest services
   copy:
       src: "{{ item }}"
       dest: /etc/systemd/system/{{ item }}
       mode: 0644
   with_items:
-      - openidtest.service
+      - oidctest.service
 
-- name: Start openidtest service using systemd
+- name: Start oidctest service using systemd
   systemd:
     state: started
-    name: openidtest
+    name: oidctest
     daemon_reload: yes
     enabled: yes
 

--- a/ansible/roles/openidtest/files/.bashrc
+++ b/ansible/roles/openidtest/files/.bashrc
@@ -1,6 +1,0 @@
-# .bashrc
-
-alias openidtest-start="sudo systemctl start openidtest.service && echo 'openidtest is running on https://openidtest.tinystage.test/'"
-alias openidtest-logs="sudo journalctl -u openidtest.service"
-alias openidtest-restart="sudo systemctl restart openidtest.service && echo 'openidtest is running on https://openidtest.tinystage.test/'"
-alias openidtest-stop="sudo systemctl stop openidtest.service && echo 'openidtest service stopped'"


### PR DESCRIPTION
previously, the openidtest box actually implemented openid connect
and now we need to check openid, so lets rename it to oidctest

Note that this may cause issues when recreating the environment, even when you do a vagrant destroy.

removing the .vagrant folder in the tinystage checkout, and doing a `vagrant globalstatus -- prune` fixes these issues.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>