### PR TITLE
Add mail machine (sendria)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,7 @@ machines = {
   "fedora-messaging": {"autostart": true},
   "fedocal": {},
   "test-auth": {},
+  "mail": {"autostart": true},
 }
 
 Vagrant.configure(2) do |config|

--- a/ansible/mail.yml
+++ b/ansible/mail.yml
@@ -1,0 +1,11 @@
+---
+# *mail.tinystage.test*  is a machine that runs Sendria. To use,
+# enable your other tinystage machines to send mail to the smtp server at
+# mail.tinystage.test:1025 and it is shown in the sendria UI at
+# http://mail.tinystage.test and not actually send to the email given
+- hosts: mail
+  become: true
+  become_method: sudo
+  roles:
+    - common
+    - mail

--- a/ansible/roles/mail/files/bashrc
+++ b/ansible/roles/mail/files/bashrc
@@ -1,0 +1,4 @@
+# .bashrc
+
+
+alias send-test-mail="smtpc send --host mail.tinystage.test:1025 --from dude@dudemcpants.com --to hello@example.com --subject 'Welcome!' --body 'Welcome to the tinystage mail server!'"

--- a/ansible/roles/mail/files/sendria.service
+++ b/ansible/roles/mail/files/sendria.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=sendria
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=root
+WorkingDirectory=/home/vagrant
+ExecStart=sendria --db /home/vagrant/mails.sqlite --http-ip 0.0.0.0 --http-port 80 --smtp-ip 0.0.0.0 --smtp-port 1025
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/mail/handlers/main.yml
+++ b/ansible/roles/mail/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: restart sendria
+  systemd:
+    name: sendria
+    state: restarted
+    daemon_reload: yes

--- a/ansible/roles/mail/tasks/main.yml
+++ b/ansible/roles/mail/tasks/main.yml
@@ -1,0 +1,38 @@
+- name: Install RPM packages
+  dnf:
+    name:
+      - python3-devel
+      - python3-pip
+      - git
+    state: present
+
+- name: Install Sendria from pip 
+  pip:
+    name: sendria
+
+- name: Install smtpc from pip 
+  pip:
+    name: smtpc
+
+- name: Install the .bashrc
+  copy:
+    src: bashrc
+    dest: /home/vagrant/.bashrc
+    mode: 0644
+    owner: vagrant
+    group: vagrant
+
+- name: Install the systemd unit
+  copy:
+      src: sendria.service
+      dest: /etc/systemd/system/sendria.service
+      mode: 0644
+  notify:
+    - restart sendria
+
+- name: Start service using systemd
+  systemd:
+    state: started
+    name: sendria
+    daemon_reload: yes
+    enabled: yes


### PR DESCRIPTION
This adds a new VM, mail.tinystage.test that runs Sendria. To use, enable your other tinystage machines to send mail to smtp://mail.tinystage.test:1025 and it is shown in the sendria UI at http://mail.tinystage.test

Signed-off-by: Ryan Lerch <rlerch@redhat.com>