### PR TITLE
gitleaks: allow user/pass for internal only amqp broker

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -34,4 +34,4 @@
   lineinfile:
     path: /etc/fedora-messaging/config.toml
     regexp: "amqp_url = \"amqp://\""
-    line: "amqp_url = \"amqp://fedoramessages:fedoramessages@tinystage.tinystage.test\""
+    line: "amqp_url = \"amqp://fedoramessages:fedoramessages@tinystage.tinystage.test\"" # gitleaks:allow


### PR DESCRIPTION
Signed-off-by: Kevin Fenzi <kevin@scrye.com>