### PR TITLE
Fix `rpms` namespace and other fixes

### DIFF
--- a/ansible/roles/pagure/files/dev-data.py
+++ b/ansible/roles/pagure/files/dev-data.py
@@ -111,12 +111,12 @@ def insert_data(session):
 
         except IntegrityError as e:
             session.rollback()
-        
+
         projectname = os.path.join(namespace, f'{project}.git')
         create_projects_git(_config["GIT_FOLDER"], projectname)
 
         thegroup = grouplist[int.from_bytes(bytes(project,'utf-8'), byteorder='big') % len(grouplist) ]
-        
+
         group = pagure.lib.query.search_groups(
              session, pattern=None, group_name=thegroup['groupname'], group_type=None
         )
@@ -136,25 +136,25 @@ def insert_data(session):
             is_fork=False,
             parent_id=None,
             description=f"{project} rpm",
-            namespace='rpm',
+            namespace='rpms',
             hook_token=f"{project} rpm"
         )
         p.close_status = ["Invalid", "Insufficient data", "Fixed", "Duplicate"]
         try:
-            print(f"adding {project} for user {thisusername} in namespace rpm")
+            print(f"adding {project} for user {thisusername} in namespace rpms")
             session.add(p)
             session.commit()
         except IntegrityError as e:
             session.rollback()
 
-        projectname = os.path.join("rpm", f'{project}.git')
+        projectname = os.path.join("rpms", f'{project}.git')
         create_projects_git(_config["GIT_FOLDER"], projectname)
 
         thegroup = grouplist[int.from_bytes(bytes(project,'utf-8'), byteorder='big') % len(grouplist) ]
         group = pagure.lib.query.search_groups(
              session, pattern=None, group_name=thegroup['groupname'], group_type=None
         )
-        repo = pagure.lib.query.get_authorized_project(session, project, namespace='rpm')
+        repo = pagure.lib.query.get_authorized_project(session, project, namespace='rpms')
         item = pagure.lib.model.ProjectGroup(
         project_id=repo.id, group_id=group.id, access="commit"
         )

--- a/ansible/roles/pagure/files/dev-data.py
+++ b/ansible/roles/pagure/files/dev-data.py
@@ -43,14 +43,14 @@ def insert_data(session):
             token=None,
             default_email=user['emails'][0],
         )
-        
+
         try:
             print(f"adding user {user['username']}")
             session.add(u)
             session.commit()
         except IntegrityError:
             session.rollback()
-    
+
     grouplist = c.list_groups().result
 
     for group in grouplist:
@@ -77,7 +77,7 @@ def insert_data(session):
             u = pagure.lib.query.get_user(
                 session, key=member['username']
             )
-            
+
             try:
                 print(f"adding user {member['username']} to group {group['groupname']}")
                 session.add(pagure.lib.model.PagureUserGroup(user_id=u.id, group_id=g.id))

--- a/ansible/roles/pagure/tasks/main.yml
+++ b/ansible/roles/pagure/tasks/main.yml
@@ -22,6 +22,7 @@
   ansible.builtin.git:
     repo: 'https://pagure.io/pagure.git'
     dest: /home/vagrant/pagure
+    force: true
 
 # installing pygit2 from pip was causing issues, so we just
 # use the RPM version instead. Here we just yank that line
@@ -57,6 +58,11 @@
     src: pagure.cfg
     dest: /home/vagrant/pagure/lcl/pagure.cfg
 
+
+- name: wipe database
+  file:
+    path: /var/tmp/pagure_dev.sqlite
+    state: absent
 
 - name: create database
   command: python createdb.py --initial alembic.ini

--- a/ansible/roles/pagure/tasks/main.yml
+++ b/ansible/roles/pagure/tasks/main.yml
@@ -26,7 +26,7 @@
 # installing pygit2 from pip was causing issues, so we just
 # use the RPM version instead. Here we just yank that line
 # from  our checked out requirements.txt
-- name: remove pygit2 fron pip install
+- name: remove pygit2 from pip install
   ansible.builtin.lineinfile:
     path: /home/vagrant/pagure/requirements.txt
     regexp: '^pygit2'
@@ -87,7 +87,7 @@
     enabled: yes
     daemon_reload: yes
 
-- name: Enable and start pagure 
+- name: Enable and start pagure
   systemd:
     state: started
     name: pagure
@@ -97,7 +97,7 @@
 - name: kinit
   shell: echo {{ ipa_admin_password }} | kinit {{ ipa_admin_user }}@{{ krb_realm }}
 
-- name: copy alembic.ini
+- name: install dev data creation script
   copy:
     src: dev-data.py
     dest: /home/vagrant/pagure/dev-data.py


### PR DESCRIPTION
```
commit d6c7279f6c2b177e82c381a289c566caefc3807f
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Mar 30 13:39:18 2023 +0200

    Fix typos and trailing white space
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 820351ca778589823bc8f163d4eb3b56db73dca3
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Mar 30 14:36:17 2023 +0200

    Make pagure role more robust
    
    Force checkout of the Pagure repo to overwrite existing files
    overwritten by the role and wipe the database before attempting to fill
    it with test data.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit de3268169a7d225756267279282bcd17cd059841
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Mar 30 13:32:20 2023 +0200

    Fix `rpms` namespace
    
    We use `rpms` in Fedora infrastructure and e.g. FMN relies on that.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```