### PR TITLE
Tweak pagure box so we can create projects

### DIFF
--- a/ansible/roles/pagure/files/pagure.cfg
+++ b/ansible/roles/pagure/files/pagure.cfg
@@ -130,7 +130,7 @@ REDIS_DB = 0
 # `local`
 # Default: ``fas``.
 PAGURE_AUTH = 'oidc'
-OIDC_CLIENT_SECRETS = "/home/vagrant/client_secrets.json"
+OIDC_CLIENT_SECRETS = "/etc/pagure/client_secrets.json"
 OIDC_SCOPES = [
     'openid', 'email', 'profile',
     'https://id.fedoraproject.org/scope/agreements',

--- a/ansible/roles/pagure/files/pagure.service
+++ b/ansible/roles/pagure/files/pagure.service
@@ -3,10 +3,12 @@ Description=The Pagure web service
 After=network.target
 
 [Service]
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 Environment="PAGURE_CONFIG=/etc/pagure/pagure.cfg"
 ExecStart=python3 /srv/pagure/runserver.py --host 0.0.0.0 --debug --port 443
 Type=simple
-User=root
+User=git
+Group=git
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/pagure/tasks/main.yml
+++ b/ansible/roles/pagure/tasks/main.yml
@@ -70,7 +70,7 @@
   lineinfile:
     path: /srv/pagure/runserver.py
     search_string: "APP.run(host=args.host, port=int(args.port))"
-    line: "APP.run(host=args.host, port=int(args.port),ssl_context=(\"/etc/pki/tls/certs/server.pem\",\"/etc/pki/tls/private/server.key\"))"
+    line: "APP.run(host=args.host, port=int(args.port),ssl_context=(\"/etc/pagure/server.pem\",\"/etc/pagure/server.key\"))"
 
 - name: Create the folder where we'll place the symbolic link for pagure
   file:
@@ -162,6 +162,33 @@
 
 
 # Configure the web app
+
+- name: Add a copy of client_secrets to where pagure can use it
+  copy:
+    src: /home/vagrant/client_secrets.json
+    dest: /etc/pagure/client_secrets.json
+    owner: git
+    group: git
+    mode: 0644
+    remote_src: True
+
+- name: Add a copy of server.pem to where pagure can use it
+  copy:
+    src: /etc/pki/tls/certs/server.pem
+    dest: /etc/pagure/server.pem
+    owner: git
+    group: git
+    mode: 0644
+    remote_src: True
+
+- name: Add a copy of server.key to where pagure can use it
+  copy:
+    src: /etc/pki/tls/private/server.key
+    dest: /etc/pagure/server.key
+    owner: git
+    group: git
+    mode: 0644
+    remote_src: True
 
 - name: Install the pagure configuration
   copy:


### PR DESCRIPTION
Previously, the way I set up the pagure box, we were running the main pagure.service as root, primarily becasue we needed it to serve over port 443. However, because of this the permissions were messed up after creating a new project such that creating projects didnt wrok. Now we go back to running the service under the git user (like is done in the pagure upstream src vagrant box) and making copies of some of the files pagure needs for OIDC auth to where pagure and the git user can see them