### PR TITLE
ignore git safety warnings as we are not under attack

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -8,6 +8,7 @@
     - git
     - python3
     - fedora-messaging
+    - git
     state: present
 
 - name: Determine Python version
@@ -57,3 +58,6 @@
     owner: root
     group: root
     mode: 0644
+    
+- name: set git to ignore safety warnings added in git 2.36 https://github.blog/2022-04-18-highlights-from-git-2-36/#stricter-repository-ownership-checks 
+  command: git config --global --add safe.directory /vagrant/freeipa-fas

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -60,4 +60,4 @@
     mode: 0644
     
 - name: set git to ignore safety warnings added in git 2.36 https://github.blog/2022-04-18-highlights-from-git-2-36/#stricter-repository-ownership-checks 
-  command: git config --global --add safe.directory /vagrant/freeipa-fas
+  command: git config --global --add safe.directory '*'

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -61,3 +61,4 @@
     
 - name: set git to ignore safety warnings added in git 2.36 https://github.blog/2022-04-18-highlights-from-git-2-36/#stricter-repository-ownership-checks 
   command: git config --global --add safe.directory '*'
+  become_user: vagrant


### PR DESCRIPTION
This adds an ansible step to the `common` role to configure git such that later stages of the install (per #60) wont fail

fixes #60 