### PR TITLE
Copy CA cert to synced folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,39 @@ Tiny Stage populates the IPA database with many users, and for ease of use, they
 
 ## Seeing users and Groups in the IPA admin webUI
 
-Since it's your tinystage, you have access to the IPA WebUI as admin. got to https://ipa.tinystage.test/ and log in with the username `admin` and the password `password` and you can view all the users and groups, and change any details.
+Since it's your tinystage, you have access to the IPA WebUI as admin. Go to https://ipa.tinystage.test/ and log in with the username `admin` and the password `password` and you can view all the users and groups, and change any details.
 ![image](https://user-images.githubusercontent.com/592259/122032526-11025c80-ce13-11eb-9a21-66c9047c232e.png)
+
+## Access to ipalib's API
+
+No need to start all the VMs, the `ipa` one is enough:
+
+```
+vagrant up ipa
+vagrant ssh ipa
+```
+
+The ipalib API is accessible from the python console. It's necessary to pass envvars KRB5_CONFIG and IPA_CONFDIR:
+
+```
+KRB5_CONFIG=krb5.conf IPA_CONFDIR=<path_to>/synced_folders/ipa/ipa ipython
+```
+
+Inside the console initialize API access:
+```
+from ipalib import api
+api.bootstrap(context="custom")
+api.finalize()
+```
+Create a connection:
+
+```
+api.Backend.rpcclient.connect()
+```
+
+Run the ipalib API commads:
+```
+api.Command.user_find()
+```
+More information in the freeipa guide: https://freeipa.readthedocs.io/en/latest/api/basic_usage.html
 

--- a/ansible/roles/freeipa/tasks/main.yml
+++ b/ansible/roles/freeipa/tasks/main.yml
@@ -61,11 +61,19 @@
   args:
     creates: /var/lib/ipa/backup/backup-clean
 
-- name: copy the CA cert to the vagrant dir
+- name: Create the ipa dir in synced_folders
+  file:
+    path: /vagrant/ipa
+    state: directory
+
+- name: copy the IPA files to the vagrant dir
   copy:
     remote_src: true
-    src: /etc/ipa/ca.crt
-    dest: /vagrant/ca.crt
+    src: /etc/ipa/{{item}}
+    dest: /vagrant/ipa/{{item}}
+  loop:
+    - ca.crt
+    - default.conf
 
 - name: Install the bashrc
   template:

--- a/krb5.conf
+++ b/krb5.conf
@@ -14,8 +14,8 @@
  TINYSTAGE.TEST = {
         kdc = https://ipa.tinystage.test/KdcProxy
         kpasswd_server = https://ipa.tinystage.test/KdcProxy
-        pkinit_anchors = FILE:./synced_folders/ipa/ca.crt
-        http_anchors = FILE:./synced_folders/ipa/ca.crt
+        pkinit_anchors = FILE:./synced_folders/ipa/ipa/ca.crt
+        http_anchors = FILE:./synced_folders/ipa/ipa/ca.crt
  }
 [domain_realm]
  .tinystage.test = TINYSTAGE.TEST


### PR DESCRIPTION
The default.conf and ca.crt are placed to an ipa directory and copied to ipa directory in vagrant. Changes originating from requirements of ipalib. 