### PR TITLE
rabbitmq: ensure checkpolicy is available

### DIFF
--- a/ansible/roles/rabbitmq/tasks/main.yml
+++ b/ansible/roles/rabbitmq/tasks/main.yml
@@ -3,6 +3,8 @@
       name: "{{ item }}"
       state: present
   with_items:
+      - checkpolicy
+      - policycoreutils-python-utils
       - rabbitmq-server
       - fedora-messaging
 


### PR DESCRIPTION
Otherwise, the SELinux steps in the provisioning Ansible role will fail with an error about being unable to find `checkmodule`.