### PR TITLE
Use the global python interpreter

### DIFF
--- a/ansible/roles/fasjson/templates/httpd.conf
+++ b/ansible/roles/fasjson/templates/httpd.conf
@@ -7,7 +7,7 @@ WSGIDaemonProcess fasjson processes=4 threads=1 maximum-requests=500 \
   display-name=%{GROUP} socket-timeout=2147483647 \
   lang=C.UTF-8 locale=C.UTF-8
 WSGIImportScript /srv/fasjson.wsgi \
-    process-group=fasjson application-group=fasjson
+    process-group=fasjson application-group=%{GLOBAL}
 WSGIScriptAlias /fasjson /srv/fasjson.wsgi
 WSGIScriptReloading Off
 
@@ -26,7 +26,7 @@ SSLCertificateKeyFile /etc/pki/tls/private/fasjson.key
 
 <Location "/fasjson">
   WSGIProcessGroup fasjson
-  WSGIApplicationGroup fasjson
+  WSGIApplicationGroup %{GLOBAL}
   Require all granted
   ErrorDocument 401 /fasjson/errors/401
   ErrorDocument 403 /fasjson/errors/403

--- a/ansible/roles/noggin/templates/httpd.conf
+++ b/ansible/roles/noggin/templates/httpd.conf
@@ -7,12 +7,12 @@ WSGIDaemonProcess noggin processes=2 threads=2 maximum-requests=500 \
   display-name=%{GROUP} socket-timeout=2147483647 \
   lang=C.UTF-8 locale=C.UTF-8 python-home={{poetry_virtualenv_path.stdout}}
 WSGIImportScript /srv/noggin.wsgi \
-    process-group=noggin application-group=noggin
+    process-group=noggin application-group=%{GLOBAL}
 WSGIScriptAlias /noggin /srv/noggin.wsgi
 WSGIScriptReloading Off
 
 <Location "/noggin">
   WSGIProcessGroup noggin
-  WSGIApplicationGroup noggin
+  WSGIApplicationGroup %{GLOBAL}
   Require all granted
 </Location>

--- a/ansible/roles/test-auth/files/httpd.conf
+++ b/ansible/roles/test-auth/files/httpd.conf
@@ -7,13 +7,13 @@ WSGIDaemonProcess test-auth processes=1 threads=2 maximum-requests=500 \
   display-name=%{GROUP} socket-timeout=2147483647 \
   lang=C.UTF-8 locale=C.UTF-8
 WSGIImportScript /srv/test-auth.wsgi \
-    process-group=test-auth application-group=test-auth
+    process-group=test-auth application-group=%{GLOBAL}
 WSGIScriptAlias /test-auth /srv/test-auth.wsgi
 WSGIScriptReloading Off
 
 <Location "/test-auth">
   WSGIProcessGroup test-auth
-  WSGIApplicationGroup test-auth
+  WSGIApplicationGroup %{GLOBAL}
   Require all granted
 </Location>
 


### PR DESCRIPTION
The Python cryptography module uses PyO3 under the hood to interact with rust-based code. Unfortunately, PyO3 cannot operate in a subinterpreter at this time, and so the applications crash. To work around this, we can tell them to operate in the global interpreter configuration instead.

See https://github.com/PyO3/pyo3/issues/576 for details on the upstream issue.