### PR TITLE
Fix default machine count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Then run vagrant to create the 3 default machines (ipa, auth, tinystage):
 $ vagrant up
 ```
 
-This process will take a while, but when complete you will then be able to access the 4 default machines.
+This process will take a while, but when complete you will then be able to access the 3 default machines.
 
 To create a non default machine, simply run the vagrant up command with the name of the machine. For example, to create the elections application, run the command:
 


### PR DESCRIPTION
The README currently states that `vagrant up` creates 3 default machines (ipa, auth, tinystage), but the next line mentions access to 4 default machines.

This creates confusion for new users.

Corrected "4 default machines" to "3 default machines"

To maintain consistency and improve clarity in the installation instructions.